### PR TITLE
Chi/pawn promotion

### DIFF
--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -61,18 +61,21 @@ class PiecesController < ApplicationController
     turn = @piece.game.turn
     white_player_id = @piece.game.white_player_id
     black_player_id = @piece.game.black_player_id
-    kings = @piece.game.pieces.where( type: "King" )
+    if @piece.type == "Pawn"
+      pawn_promoted = @piece.can_promote?
+    end
+
+    kings = @piece.game.pieces.where(type: "King")
     kings.each do |curr_king|
       if curr_king.if_checkmate?(board) == true
         if @piece.game.white_player_id != curr_king.player_id
            @piece.game.winner_id = @piece.game.white_player_id
-        else 
+        else
            @piece.game.winner_id = @piece.game.black_player_id
-        end 
+        end
           @piece.game.save
-      end 
-     end 
-  
+      end
+    end
 
     render json: { piece: @piece, turn: turn, white_player_id: white_player_id, black_player_id: black_player_id }
 
@@ -91,8 +94,8 @@ class PiecesController < ApplicationController
                     x_captured: x_captured,
                     move_turn: Move.last.turn,
                     type: @piece.type,
-                    winner_id: @piece.game.winner_id
-                    )
+                    winner_id: @piece.game.winner_id,
+                    pawn_promoted: pawn_promoted)
   end
 
   private

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -38,9 +38,9 @@ class PiecesController < ApplicationController
     @piece = Piece.find(params[:id])
     old_row = @piece.y_position
     old_cell = @piece.x_position
-
     row = params[:y_position].to_i
     cell = params[:x_position].to_i
+    type = @piece.type
 
     if @piece.type == "Pawn"
       pawn_promoted = true if @piece.white_player? && row == 7 || @piece.black_player? && row == 0
@@ -94,7 +94,7 @@ class PiecesController < ApplicationController
                     y_captured: y_captured,
                     x_captured: x_captured,
                     move_turn: Move.last.turn,
-                    type: @piece.type,
+                    type: type,
                     winner_id: @piece.game.winner_id,
                     pawn_promoted: pawn_promoted)
   end

--- a/app/controllers/pieces_controller.rb
+++ b/app/controllers/pieces_controller.rb
@@ -42,6 +42,10 @@ class PiecesController < ApplicationController
     row = params[:y_position].to_i
     cell = params[:x_position].to_i
 
+    if @piece.type == "Pawn"
+      pawn_promoted = true if @piece.white_player? && row == 7 || @piece.black_player? && row == 0
+    end
+
     @game = @piece.game
     if @piece.occupied_space?(row, cell) == true
       captured_piece = @game.pieces.where(y_position: row, x_position: cell, captured_piece: false).last
@@ -61,9 +65,6 @@ class PiecesController < ApplicationController
     turn = @piece.game.turn
     white_player_id = @piece.game.white_player_id
     black_player_id = @piece.game.black_player_id
-    if @piece.type == "Pawn"
-      pawn_promoted = @piece.can_promote?
-    end
 
     kings = @piece.game.pieces.where(type: "King")
     kings.each do |curr_king|

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -71,17 +71,13 @@ class Game < ActiveRecord::Base
       piece = Pawn.create(game_id: id, player_id: black_player_id, x_position: i, y_position: 6)
       Move.create(piece_id: piece.id, x: i, y: 6, turn: 0 )
     end
-
-
-    
-
   end
 
   def moves
     # q = "select p.email, c.type, m.turn from players p, pieces c, moves m  where m.piece_id = c.id and c.player_id = p.id"
     # r = ActiveRecord::Base.connection.execute(q)
     # r.values
-    query = "SELECT pieces.type, moves.turn, pieces.game_id, moves.x, moves.y FROM players, pieces, moves WHERE moves.piece_id = pieces.id AND pieces.player_id = players.id AND pieces.game_id = #{self.id} AND moves.x = moves.x AND moves.y = moves.y"
+    query = "SELECT pieces.type, moves.turn, pieces.game_id, moves.y, moves.x FROM players, pieces, moves WHERE moves.piece_id = pieces.id AND pieces.player_id = players.id AND pieces.game_id = #{self.id} AND moves.x = moves.x AND moves.y = moves.y"
     results = ActiveRecord::Base.connection.execute(query)
     results.values  # [["Rook", "0"], ["phagmann1@gmail.com", "Rook", "0"],... [ [ type, turn#, y, x, piece_id]]
 

--- a/app/models/pawn.rb
+++ b/app/models/pawn.rb
@@ -33,31 +33,4 @@ class Pawn < Piece
     def can_promote?
       white_player? && y_position == 7 || black_player? && y_position == 0
     end
-
-
-    # def piece_can_move_to(board)
-
-        # piece logic goes inside this method
-
-        # you are already given a 'board' which is a 2D array. It mimics the actual database board,
-        # 0 represents an empty space and the particular number matchs such that:
-        # board_start = [[1, 1, 1, 1, 1, 1, 1, 1],
-        #                [1, 1, 1, 1, 1, 1, 1, 1],
-        #                [0, 0, 0, 0, 0, 0, 0, 0],
-        #                [0, 0, 0, 0, 0, 0, 0, 0],
-        #                [0, 0, 0, 0, 0, 0, 0, 0],
-        #                [0, 0, 0, 0, 0, 0, 0, 0],
-        #                [2, 2, 2, 2, 2, 2, 2, 2],
-        #                [2, 2, 2, 2, 2, 2, 2, 2]]
-        # 1 would be the white player and 2 would be the black player,
-        # but these numbers are suppost to be the same as their "player_id".
-        # so if black had a player_id of 5, then where you see 2's, they would be 5's
-        # don't worry
-
-
-
-        # 'piece_can_move_to' should RETURN an array of cordinates, [x,y] ,
-        # such that they match this piece's logic: [[3,4] ,[5,7], [0,1]...]
-
-    # end
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -190,17 +190,7 @@ $(function() {
     var pieceUpdateRef = rootRef.child(gameID);
     var moveRef = rootRef.child(gameID);
     var mateRef = rootRef.child(gameID);
-    var pawnPromoteRef = rootRef.child(gameID);
-
-    pawnPromoteRef.on('value', function(snapshot) {
-      var data = snapshot.val();
-      if (data) {
-        if (data.pawn_promoted) {
-          var square = $("#square-" + data.y_update + "-" + data.x_update);
-        }
-      }
-    });
-
+    
     mateRef.on('value', function(snapshot) {
       var data = snapshot.val();
       if (data) {
@@ -280,8 +270,21 @@ $(function() {
             var color = "black"
           }
 
+          // check if pawn promoted
           // append piece to destination square
-          square.append("<div class='piece' data-piece-id='" + data.pieceId + "' data-piece-color='" + color + "'>" + piece + "</div>");
+          if (data.pawn_promoted) {
+            if (data.turn == data.black_player_id) {
+                // append white queen (since turn has changed)
+                square.append("<div class='piece' data-piece-id='" + data.pieceId + "' data-piece-color='" + color + "'>" + '\u2655' + "</div>");
+            }
+            if (data.turn == data.white_player_id) {
+                // append black queen (since turn has changed)
+                square.append("<div class='piece' data-piece-id='" + data.pieceId + "' data-piece-color='" + color + "'>" + '\u265B' + "</div>");
+            }
+          } else {
+            square.append("<div class='piece' data-piece-id='" + data.pieceId + "' data-piece-color='" + color + "'>" + piece + "</div>");
+          };
+
           square.switchClass('empty', 'not-selectable');
 
           // clear square that piece came from

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -42,170 +42,141 @@
         <%= '<tr>'.html_safe %>
           <% 8.times do |cell| %>
 
-              <!-- square has a piece and piece is selected -->
-              <% if @board[row][cell] != 0 && selected_piece_id != 0 %>
-                <% if (selected_piece_id.x_position == cell && selected_piece_id.y_position == row) %>
-                  <td class="selected" data-y-position="<%=row%>" data-x-position="<%=cell%>" id="square-<%=row%>-<%=cell%>">
-                    <% piece = active_pieces[piece_trace] %>
-                    <% piece_trace += 1 %>
-
-                    <div class="selected_piece" data-piece-id="<%=piece.id%>" data-piece-color="<%= piece.player_id == @game.white_player_id ? "white" : "black" %>">
-                      <%= "#{piece.symbol}".html_safe %>
-                    </div>
-
-                    <% next %>
-                  </td>
-                <% end %>
-              <% end %>
-
-              <!-- empty square can't be moved to because king is in check -->
-              <% if pieces_attacking_king != [] && selected_piece_id != 0 && @board[row][cell] == 0%>
-                <% if !selected_piece_id.checkmoves(current_king, pieces_attacking_king, @board ).include?([row,cell]) %>
-                  <td class="empty" id="square-<%=row%>-<%=cell%>">
-
-                  </td>
-                  <% next %>
-                <% end %>
-              <% end %>
-
-              <!-- piece can't be moved to because king is in check -->
-              <% if pieces_attacking_king != [] && selected_piece_id != 0 && @board[row][cell] != 0%>
-
-                <% if !selected_piece_id.checkmoves(current_king, pieces_attacking_king, @board ).include?([row,cell]) %>
-                  <td class="selectable" id="square-<%=row%>-<%=cell%>">
+            <!-- square has a piece and piece is selected -->
+            <% if @board[row][cell] != 0 && selected_piece_id != 0 %>
+              <% if (selected_piece_id.x_position == cell && selected_piece_id.y_position == row) %>
+                <td class="selected" data-y-position="<%=row%>" data-x-position="<%=cell%>" id="square-<%=row%>-<%=cell%>">
                   <% piece = active_pieces[piece_trace] %>
                   <% piece_trace += 1 %>
-
-                  <div class="piece" data-piece-id="<%=piece.id%>" data-piece-color="<%= piece.player_id == @game.white_player_id ? "white" : "black" %>">
+                  <div class="selected_piece" data-piece-id="<%=piece.id%>" data-piece-color="<%= piece.player_id == @game.white_player_id ? "white" : "black" %>">
                     <%= "#{piece.symbol}".html_safe %>
                   </div>
-
-
-                </td>
-                  <% next %>
-                <% end %>
-              <% end %>
-
-              <!-- square has a piece and it's signed-in player's turn (can hover over piece)-->
-              <!-- Note: s -->
-              <% if @board[row][cell] != 0 && @board[row][cell] == @game.turn && current_player.id == @game.turn %>
-                <td class="selectable" data-y-position="<%=row%>" data-x-position="<%=cell%>" id="square-<%=row%>-<%=cell%>">
-                  <% piece = active_pieces[piece_trace] %>
-                  <% piece_trace += 1 %>
-
-                    <div class="selectable_piece" data-piece-id="<%=piece.id%>" data-piece-color="<%= piece.player_id == @game.white_player_id ? "white" : "black" %>">
-                      <%= "#{piece.symbol}".html_safe %>
-                    </div>
-
-
                   <% next %>
                 </td>
               <% end %>
+            <% end %>
 
-              <!-- square does not have a piece -->
-              <% if @board[row][cell] == 0 %>
-                <% if selected_piece_id == 0 %>
-                  <td class="empty" id="square-<%=row%>-<%=cell%>">
-
-                  </td>
-
-                <% elsif !selected_piece_id.piece_can_move_to(@board).include?([row,cell]) %>
-
-                  <td class="empty" id="square-<%=row%>-<%=cell%>">
-
-                  </td>
-
-                <% else %>
-                <td class="highlighted" data-y-position="<%=row%>" data-x-position="<%=cell%>" id="square-<%=row%>-<%=cell%>">
-
+            <!-- empty square can't be moved to because king is in check -->
+            <% if pieces_attacking_king != [] && selected_piece_id != 0 && @board[row][cell] == 0%>
+              <% if !selected_piece_id.checkmoves(current_king, pieces_attacking_king, @board ).include?([row,cell]) %>
+                <td class="empty" id="square-<%=row%>-<%=cell%>">
                 </td>
-                <% end %>
                 <% next %>
               <% end %>
+            <% end %>
+
+            <!-- piece can't be moved to because king is in check -->
+            <% if pieces_attacking_king != [] && selected_piece_id != 0 && @board[row][cell] != 0%>
+              <% if !selected_piece_id.checkmoves(current_king, pieces_attacking_king, @board ).include?([row,cell]) %>
+                <td class="selectable" id="square-<%=row%>-<%=cell%>">
+                <% piece = active_pieces[piece_trace] %>
+                <% piece_trace += 1 %>
+                <div class="piece" data-piece-id="<%=piece.id%>" data-piece-color="<%= piece.player_id == @game.white_player_id ? "white" : "black" %>">
+                  <%= "#{piece.symbol}".html_safe %>
+                </div>
+              </td>
+                <% next %>
+              <% end %>
+            <% end %>
+
+            <!-- square has a piece and it's signed-in player's turn (can hover over piece)-->
+            <% if @board[row][cell] != 0 && @board[row][cell] == @game.turn && current_player.id == @game.turn %>
+              <td class="selectable" data-y-position="<%=row%>" data-x-position="<%=cell%>" id="square-<%=row%>-<%=cell%>">
+                <% piece = active_pieces[piece_trace] %>
+                <% piece_trace += 1 %>
+                  <div class="selectable_piece" data-piece-id="<%=piece.id%>" data-piece-color="<%= piece.player_id == @game.white_player_id ? "white" : "black" %>">
+                    <%= "#{piece.symbol}".html_safe %>
+                  </div>
+                <% next %>
+              </td>
+            <% end %>
+
+            <!-- square does not have a piece -->
+            <% if @board[row][cell] == 0 %>
+              <% if selected_piece_id == 0 %>
+                <td class="empty" id="square-<%=row%>-<%=cell%>"></td>
+              <% elsif !selected_piece_id.piece_can_move_to(@board).include?([row,cell]) %>
+                <td class="empty" id="square-<%=row%>-<%=cell%>"></td>
+              <% else %>
+                <td class="highlighted" data-y-position="<%=row%>" data-x-position="<%=cell%>" id="square-<%=row%>-<%=cell%>"></td>
+              <% end %>
+              <% next %>
+            <% end %>
 
               <!-- square has a piece that can be captured
                     current issue: capturing destination doesn't get called because identical if statement
                     getting called on line 55-->
-              <% if @board[row][cell] != current_player.id && @board[row][cell] != 0 && selected_piece_id != 0%>
-
-
-                <% if selected_piece_id.piece_can_move_to(@board).include?([row,cell]) %>
-                  <td class="highlighted" data-y-position="<%=row%>" data-x-position="<%=cell%>" id="square-<%=row%>-<%=cell%>">
-                    <% piece = active_pieces[piece_trace] %>
-                    <% piece_trace += 1 %>
-                    <div class="piece" data-piece-id="<%=piece.id%>" data-piece-color="<%= piece.player_id == @game.white_player_id ? "white" : "black" %>">
-                      <%= "#{piece.symbol}".html_safe %>
-                    </div>
-
-                  </td>
-                <% else %>
-                  <td class="not-selectable" id="square-<%=row%>-<%=cell%>">
+            <% if @board[row][cell] != current_player.id && @board[row][cell] != 0 && selected_piece_id != 0%>
+              <% if selected_piece_id.piece_can_move_to(@board).include?([row,cell]) %>
+                <td class="highlighted" data-y-position="<%=row%>" data-x-position="<%=cell%>" id="square-<%=row%>-<%=cell%>">
                   <% piece = active_pieces[piece_trace] %>
                   <% piece_trace += 1 %>
-
                   <div class="piece" data-piece-id="<%=piece.id%>" data-piece-color="<%= piece.player_id == @game.white_player_id ? "white" : "black" %>">
                     <%= "#{piece.symbol}".html_safe %>
                   </div>
-
-
                 </td>
-                <% end %>
-                <% next %>
+              <% else %>
+                <td class="not-selectable" id="square-<%=row%>-<%=cell%>">
+                <% piece = active_pieces[piece_trace] %>
+                <% piece_trace += 1 %>
+                <div class="piece" data-piece-id="<%=piece.id%>" data-piece-color="<%= piece.player_id == @game.white_player_id ? "white" : "black" %>">
+                  <%= "#{piece.symbol}".html_safe %>
+                </div>
+              </td>
               <% end %>
+              <% next %>
+            <% end %>
 
-              <!-- square has a piece but it's not signed-in player's turn (can't hover over piece) or theres a check -->
-              <% if @board[row][cell] != 0 %>
-                  <td class="not-selectable" id="square-<%=row%>-<%=cell%>">
-                  <% piece = active_pieces[piece_trace] %>
-                    <% piece_trace += 1 %>
-
-                    <div class="piece" data-piece-id="<%=piece.id%>" data-piece-color="<%= piece.player_id == @game.white_player_id ? "white" : "black" %>">
-                      <%= "#{piece.symbol}".html_safe %>
-                    </div>
-
-                    <% next %>
-                  </td>
-              <% end %>
-           <% end %>
-
+            <!-- square has a piece but it's not signed-in player's turn (can't hover over piece) or theres a check -->
+            <% if @board[row][cell] != 0 %>
+                <td class="not-selectable" id="square-<%=row%>-<%=cell%>">
+                <% piece = active_pieces[piece_trace] %>
+                  <% piece_trace += 1 %>
+                  <div class="piece" data-piece-id="<%=piece.id%>" data-piece-color="<%= piece.player_id == @game.white_player_id ? "white" : "black" %>">
+                    <%= "#{piece.symbol}".html_safe %>
+                  </div>
+                  <% next %>
+                </td>
+            <% end %>
+         <% end %>
         <%= '</tr>'.html_safe %>
       <% end %>
     </table>
   </div>
 </div>
 
-  <br /><br /><br />
-  <div class="col-xs-12 col-sm-6">
-    <br /><br />
-    <div class="col-xs-12" id="log">
-      <p><b>Moves List:</b></p>
-      <script >
-        moveLog(<%= current_king.id %>)
-      </script>
-    </div>
+<br /><br /><br />
+<div class="col-xs-12 col-sm-6">
+  <br /><br />
+  <div class="col-xs-12" id="log">
+    <p><b>Moves List:</b></p>
+    <script >
+      moveLog(<%= current_king.id %>)
+    </script>
+  </div>
 
-  <br />
-    <div class="captured col-xs-12">
-      <br />
-        <% captured_white_pieces = @game.pieces.where(captured_piece: true).where('player_id = ?', @game.white_player_id).order(y_position: :asc, x_position: :asc) %>
-        <div class="captured-white col-xs-12 text-center">
-            <% if @game.pieces.where(captured_piece: true).where('player_id = ?', @game.white_player_id).any? %>
-              <h5>captured white pieces:</h5>
-            <% end %>
-            <% captured_white_pieces.each do |piece| %>
-              <%= "#{piece.symbol}".html_safe %>
-            <% end %>
-        </div>
-        <% captured_black_pieces = @game.pieces.where(captured_piece: true).where('player_id = ?', @game.black_player_id).order(y_position: :asc, x_position: :asc) %>
-        <div class="captured-black col-xs-12 text-center">
-          <% if @game.pieces.where(captured_piece: true).where('player_id = ?', @game.black_player_id).any? %>
-            <h5>captured black pieces:</h5>
+<br />
+  <div class="captured col-xs-12">
+    <br />
+      <% captured_white_pieces = @game.pieces.where(captured_piece: true).where('player_id = ?', @game.white_player_id).order(y_position: :asc, x_position: :asc) %>
+      <div class="captured-white col-xs-12 text-center">
+          <% if @game.pieces.where(captured_piece: true).where('player_id = ?', @game.white_player_id).any? %>
+            <h5>captured white pieces:</h5>
           <% end %>
-          <% captured_black_pieces.each do |piece| %>
-              <%= "#{piece.symbol}".html_safe %>
+          <% captured_white_pieces.each do |piece| %>
+            <%= "#{piece.symbol}".html_safe %>
           <% end %>
-        </div>
-    </div>
+      </div>
+      <% captured_black_pieces = @game.pieces.where(captured_piece: true).where('player_id = ?', @game.black_player_id).order(y_position: :asc, x_position: :asc) %>
+      <div class="captured-black col-xs-12 text-center">
+        <% if @game.pieces.where(captured_piece: true).where('player_id = ?', @game.black_player_id).any? %>
+          <h5>captured black pieces:</h5>
+        <% end %>
+        <% captured_black_pieces.each do |piece| %>
+            <%= "#{piece.symbol}".html_safe %>
+        <% end %>
+      </div>
+  </div>
 
 <script>
 
@@ -219,6 +190,16 @@ $(function() {
     var pieceUpdateRef = rootRef.child(gameID);
     var moveRef = rootRef.child(gameID);
     var mateRef = rootRef.child(gameID);
+    var pawnPromoteRef = rootRef.child(gameID);
+
+    pawnPromoteRef.on('value', function(snapshot) {
+      var data = snapshot.val();
+      if (data) {
+        if (data.pawn_promoted) {
+          var square = $("#square-" + data.y_update + "-" + data.x_update);
+        }
+      }
+    });
 
     mateRef.on('value', function(snapshot) {
       var data = snapshot.val();


### PR DESCRIPTION
Fix pawn promotion so that piece updates to queen in realtime.

Also fix moves.x and moves.y from query in games controller. (They were in reverse order, causing browser to display coords in reverse order on page refresh).

